### PR TITLE
Increase output length by one frame

### DIFF
--- a/src/samplerate.rs
+++ b/src/samplerate.rs
@@ -120,14 +120,16 @@ impl Samplerate {
     /// If the number of channels used was not `1` (Mono), the samples are expected to be stored
     /// interleaved.
     pub fn process(&self, input: &[f32]) -> Result<Vec<f32>, Error> {
-        self._process(input, (self.ratio() * input.len() as f64) as usize, false)
+        let channels = self.channels()?;
+        self._process(input, (self.ratio() * input.len() as f64) as usize + channels, false)
     }
     
     /// Perform a samplerate conversion on last block of given input data.
     /// If the number of channels used was not `1` (Mono), the samples are expected to be stored
     /// interleaved.
     pub fn process_last(&self, input: &[f32]) -> Result<Vec<f32>, Error> {
-        let output_len = (self.ratio() * input.len() as f64) as usize;
+        let channels = self.channels()?;
+        let output_len = (self.ratio() * input.len() as f64) as usize + channels;
         match self._process(input, output_len, true) {
             Ok(mut output) => {
                 loop {


### PR DESCRIPTION
This fixes a particularly nasty bug which shows itself only with the right value of `ratio` and after processing a signal that is long enough.

Output array length was too small, because the value of `self.ratio() * input.len()` is trimmed when casted to `usize`. As the output array was a single frame too short, `SRC_STATE` stored the additional frame in it's internal buffer. The buffer is finite and when it overflows there is no error, the converter simply drops all samples in the buffer.