### PR TITLE
Use pure-Rust version of libsamplerate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ keywords = ["audio", "samplerate"]
 license = "BSD-2-Clause"
 
 [dependencies]
-libsamplerate-sys = "0.1.5"
+libsamplerate-sys = { version = "0.1.5", optional = true }
+libsamplerate = { version = "0.1.0", optional = true }
+
+[features]
+default = ["pure-rust"]
+pure-rust = ["libsamplerate"]
+sys = ["libsamplerate-sys"]
 
 [dev-dependencies]
 hound = "3.4"

--- a/src/converter_type.rs
+++ b/src/converter_type.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "sys")]
 use libsamplerate_sys::*;
+#[cfg(feature = "pure-rust")]
+use libsamplerate::*;
+
 use std::ffi::CStr;
 use crate::error::{Error, ErrorCode};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "sys")]
 use libsamplerate_sys::*;
+#[cfg(feature = "pure-rust")]
+use libsamplerate::*;
+
 use std::ffi::CStr;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "sys")]
 extern crate libsamplerate_sys;
+#[cfg(feature = "pure-rust")]
+extern crate libsamplerate;
 
 pub mod converter_type;
 pub mod error;
@@ -7,7 +10,12 @@ pub mod samplerate;
 pub use crate::converter_type::*;
 pub use crate::error::*;
 pub use crate::samplerate::*;
+
+#[cfg(feature = "sys")]
 use libsamplerate_sys::*;
+#[cfg(feature = "pure-rust")]
+use libsamplerate::*;
+
 use std::ffi::CStr;
 
 /// Perform a simple samplerate conversion of a large chunk of audio.
@@ -40,7 +48,7 @@ pub fn convert(from_rate: u32, to_rate: u32, channels: usize, converter_type: Co
         end_of_input: 0,
         input_frames_used: 0,
         output_frames_gen: 0,
-        ..Default::default()
+        ..unsafe { std::mem::zeroed() }
     };
     let error_int = unsafe { src_simple(&mut src as *mut SRC_DATA, converter_type as i32, channels as i32) };
     let error_code = ErrorCode::from_int(error_int);

--- a/src/samplerate.rs
+++ b/src/samplerate.rs
@@ -1,6 +1,11 @@
 use crate::converter_type::ConverterType;
 use crate::error::{Error, ErrorCode};
+
+#[cfg(feature = "sys")]
 use libsamplerate_sys::*;
+#[cfg(feature = "pure-rust")]
+use libsamplerate::*;
+
 use std::clone::Clone;
 
 /// A samplerate converter. This is a wrapper around libsamplerate's `SRC_STATE` which also
@@ -107,7 +112,7 @@ impl Samplerate {
             end_of_input: if end_of_input { 1 } else { 0 },
             input_frames_used: 0,
             output_frames_gen: 0,
-            ..Default::default()
+            ..unsafe { std::mem::zeroed() }
         };
         let error_int = unsafe { src_process(self.ptr, &mut src as *mut SRC_DATA) };
         match ErrorCode::from_int(error_int) {


### PR DESCRIPTION
This enables to build `rust-samplerate` without a C compiler and CMake, etc... using https://github.com/RamiHg/rust-libsamplerate , a transpiled version of `libsamplerate`. This might helps to use this crate on some platforms (e.g. Windows/MSVC).