### PR TITLE
Add process_into* variants to allow utilizing an existing buffer

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -65,7 +65,7 @@ impl ErrorCode {
     /// Return the human-readable description for this error.
     pub fn description(&self) -> &'static str {
         match self {
-            ErrorCode::Unknown => "Unkown error.",
+            ErrorCode::Unknown => "Unknown error.",
             _ => unsafe {
                 CStr::from_ptr(src_strerror(*self as i32))
             }.to_str().unwrap()
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!(ErrorCode::SincPrepareDataBadLen.description(), "Internal error : Bad length in prepare_data ().");
         assert_eq!(ErrorCode::BadInternalState.description(), "Error : Someone is trampling on my internal state.");
         assert_eq!(ErrorCode::MaxError.description(), "Placeholder. No error defined for this error number.");
-        assert_eq!(ErrorCode::Unknown.description(), "Unkown error.");
+        assert_eq!(ErrorCode::Unknown.description(), "Unknown error.");
     }
 
     #[test]

--- a/src/samplerate.rs
+++ b/src/samplerate.rs
@@ -314,7 +314,7 @@ mod tests {
         }
         // Drain the remaining resample buffer
         loop {
-            let (input_used, output_generated) = converter.process_into_last(&[0.; 0], &mut resampled_buff).unwrap();
+            let (_, output_generated) = converter.process_into_last(&[0.; 0], &mut resampled_buff).unwrap();
             if output_generated == 0 {
                 break;
             }
@@ -341,15 +341,13 @@ mod tests {
         }
         // Drain the remaining resample buffer
         loop {
-            let (input_used, output_generated) = converter.process_into_last(&[0.; 0], &mut resampled_buff).unwrap();
+            let (_, output_generated) = converter.process_into_last(&[0.; 0], &mut resampled_buff).unwrap();
             if output_generated == 0 {
                 break;
             }
             output.extend(&resampled_buff[..output_generated])
         }
         assert_eq!(output.len(), 44100);
-
-        let mut invalid = 0;
 
         // Expect the difference between all input frames and all output frames to be less than
         // an epsilon.


### PR DESCRIPTION
For some applications, it can be useful to provide an existing buffer as it may already exist (and potentially saves up on allocating memory during a tight loop). The regular `process` function always creates a `Vec` which would internally always allocate memory, and usually deallocate shortly after it's used.

- This PR adds 2 functions:
   - `process_into`, which does the same as `process` but writes the result in a user supplied buffer and returns a tuple of the amount of data consumed and produced
   - `process_into_last`, which does the same for the `process_last`
- Adds an example to outline its use
- Adds a test similar to `samplerate_conversion` but utilizing the into functions instead

I have to note that I explicitly didn't implement the same thing for `convert` (as the fork of xhalo32 adds) because `convert` must not be called in a loop, and thus an in-place allocation of the output buffer is not performance critical (Either the user allocates in one go, potentially messing up the calculation. Or the function allocates in one go).

In fact, I believe allowing such a use might even give the wrong impression.